### PR TITLE
The French "cassation" method explained in English

### DIFF
--- a/The French "cassation" method, explained in English
+++ b/The French "cassation" method, explained in English
@@ -1,0 +1,44 @@
+# The French &quot;cassation&quot; method, explained in English
+
+_This is a short extract of an unpublished article on the &quot;cassation&quot; method as applied by the French Cour the cassation to civil proceedings before it. The_ [_Cour de cassation_](https://en.wikipedia.org/wiki/Court_of_Cassation_(France)) _is France&#39;s supreme judicial body for cases handled by &#39;judicial&#39; courts, i.e., civil cases between private parties or involving the application of private law and criminal cases. For a more detailed (albeit slightly outdated) presentation of the Cour de cassation, see_ [_this page_](https://www.courdecassation.fr/about_the_court_9256.html) _on the court&#39;s website._
+
+&quot;**Cassation&quot; explained.** A Court of cassation is a specific type of Supreme Court for civil law jurisdictions such as France, Belgium and Italy. Although it performs a judicial function, a Court of cassation is not an third appellate court but a judicial regulatory body, whose essential task is to ensure that the law laid down by it is uniformly applied by the courts and tribunals of the country.
+
+The basic premise of the &quot;cassation&quot; method is that the review of the Court of cassation is limited, in most cases, to the text of the judgement as delivered by the lower court. It follows from this premise that the Court of cassation cannot go into the case itself but only ensure that the lower court has correctly applied itself to the case before it.
+
+**Grounds of cassation.** The Court of cassation may only determine, by reviewing the text of the judgement, if the lower court :
+
+- has wrongly decided a question of law (« violation of the law ») ; or ;
+- has not recorded all the reasons that are a precondition to applying a particular legal proposition (« absence of reasons ») ; or ;
+- has recorded contradictory reasons, which would be equivalent to an absence of reasons (« contradiction of reasons »).
+
+Two other grounds can also be invoked before the Court of cassation, albeit very rarely :
+
+- the lower court has not addressed an argument which was part of the pleadings before it (« failure to reply to pleadings ») ;
+- the lower court has « perverted » the meaning of a clear and precise text in a document placed before it, e.g., an unambiguous clause of a will or a contract (« denaturation of a clear and precise text »).
+
+**Effect of cassation.** If the petition succeeds before the Court of cassation, the Court simply annuls the judgement of the lower court on one of the above grounds and remands the case to a different bench of the same lower court or, if necessary, to another lower court.
+
+**Pleadings.** The cassation method restricts pleadings before the Court of cassation to a bare minimum : every petition before the Court of cassation only lists, for each operative part of the lower court&#39;s judgement :
+
+- the operative part of the lower court&#39;s judgement which is under challenge (« dispositif ») ;
+- the verbatim reasons given by the lower court in respect of that operative part ;
+- the legal principle involved ;
+- the ground on which the annulment of that operative part is asked for (i.e. one of the grounds mentioned above).
+
+It may be noted that the absence or the contradiction of reasons can constitute both a ground and the legal principle involved (i.e. the necessity of giving reasons in a judicial determination). This subject is beyond the scope of the present article.
+
+Parties later submit detailed memoranda based on these grounds. An Advocate general assigned to the Court also submits a memorandum, also communicated to the parties, to assist the Court in arriving at its decision.
+
+**Judgements.** The cassation method also allows the Court of cassation to render very concise judgements which are limited to the pleadings before it. Thus, in case the judgement of the lower court is annulled, the Court of cassation only sets out :
+
+- the legal principle invoked in the grounds of cassation ;
+- the essential aspects of the lower court&#39;s judgement (operative part and reasons) ;
+- the ground on which the lower court&#39;s judgement has violated the above legal principle (cf. grounds of cassation)
+
+In the case of a rejection of the petition before it, the judgement of the Court of cassation simply states, for each operative part of the lower court&#39;s judgement, the grounds of cassation as raised before it and how, in its opinion, the judgement of the lower court is justified vis-à-vis those grounds.
+
+The reasoning provided by the Court of cassation itself is the subject matter of an ongoing debate in France. At present, even a landmark judgement of the French Court of cassation, holding that telephone conversations recorded without the knowledge of a party are inadmissible in evidence because they violate article 6 of the European Convention on Human Rights, runs into not more than two pages. (For an English translation, see [this page](https://www.courdecassation.fr/IMG///CO_arret0717147_080603_EN.pdf)).
+
+An analysis of the grounds invoked by the petitioner before the Court is provided by an internal memorandum drafted by one of the judges on the bench, to help with deciding the case. This memorandum may or may not be released to the public but in any case, it does not constitute a part of the judgement.
+


### PR DESCRIPTION
This is a short extract of an unpublished article on the "cassation" method as applied by the French Cour the cassation to civil proceedings before it. The Cour de cassation is France's supreme judicial body for cases handled by 'judicial' courts, i.e., civil cases between private parties or involving the application of private law and criminal cases. For a more detailed (albeit slightly outdated) presentation of the Cour de cassation, see this page on the court's website.